### PR TITLE
Update setup.cfg to pin pandas version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,7 @@ install_requires =
     # core packages
     scikit_image>=0.14.2
     dipy>=1.8.0,<1.9.0
-    pandas
+    pandas==2.0.3
     pybids>=0.16.2
     templateflow>=0.8
     pimms


### PR DESCRIPTION
I accidentally updated pandas to 2.1.4 and got a ValueError while running a script, worked when I downgraded pandas to 2.0.3:

from pandas._libs.interval import Interval
File "interval.pyx", line 1, in init pandas._libs.interval ValueError: numpy.dtype size changed, may indicate binary incompatibility. Expected 96 from C header, got 88 from PyObject

Not sure if it's just me, or if this is the appropriate way to leave a comment on this line. Not currently a bug, but could be for someone who has a later version of pandas.