### PR TITLE
Document default scalars

### DIFF
--- a/docs/source/reference/kwargs.rst
+++ b/docs/source/reference/kwargs.rst
@@ -186,7 +186,8 @@ scalars: strings and/or scalar definitions, optional
 	List of scalars to use.
 	Can be any of: "dti_fa", "dti_md", "dki_fa", "dki_md", "dki_awf",
 	"dki_mk". Can also be a scalar from AFQ.definitions.image.
-	Default: ["dti_fa", "dti_md"]
+	Default: For single shell data: ["dti_fa", "dti_md"], 
+        for multi-shell data: ["dki_fa", "dki_md"].
 
 
 ==========================================================


### PR DESCRIPTION
[This code](https://github.com/yeatmanlab/pyAFQ/blob/master/AFQ/tasks/data.py#L1130-L1138) checks and if the data is multi-shell it produces dki scalars, but current documentation suggests that users need to explicitly ask for DKI or they would get DTI. 

I think we might need to change this in another couple of places? 