### PR TITLE
Remove numpy version restrictions

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -54,7 +54,6 @@ install_requires =
     imageio>=2.0.0
     Pillow
     matplotlib
-    numpy>=2.2.0
     altair
 
 zip_safe = False


### PR DESCRIPTION
We can likely handle any numpy that DIPY can handle. I checked the changes we made for numpy 2.X, and so the code should work with numpy 1.X also.

Also,  this should help interoperate with afq insight which requires numpy == 2.0.0 (due to tensorflow)