### PR TITLE
[ENH] Make Subject Space ROIs Resample By Default

### DIFF
--- a/AFQ/api/bundle_dict.py
+++ b/AFQ/api/bundle_dict.py
@@ -722,9 +722,10 @@ class BundleDict(MutableMapping):
         If there are bundles in bundle_info with the 'space' attribute
         set to 'subject', their images (all ROIs and probability maps)
         will be resampled to the affine and shape of this image.
-        If None, resamples to DWI.
+        If None, resamples to DWI. Be careful if you use this,
+        that this is the correct choice.
         If False, no resampling will be done.
-        Default: None
+        Default: False
 
     keep_in_memory : bool, optional
         Whether, once loaded, all ROIs and probability maps will stay
@@ -779,7 +780,7 @@ class BundleDict(MutableMapping):
     def __init__(self,
                  bundle_info,
                  resample_to=None,
-                 resample_subject_to=None,
+                 resample_subject_to=False,
                  keep_in_memory=False):
         if not (isinstance(bundle_info, dict)):
             raise TypeError((

--- a/AFQ/api/bundle_dict.py
+++ b/AFQ/api/bundle_dict.py
@@ -722,6 +722,7 @@ class BundleDict(MutableMapping):
         If there are bundles in bundle_info with the 'space' attribute
         set to 'subject', their images (all ROIs and probability maps)
         will be resampled to the affine and shape of this image.
+        If None, resamples to DWI.
         If False, no resampling will be done.
         Default: None
 
@@ -778,7 +779,7 @@ class BundleDict(MutableMapping):
     def __init__(self,
                  bundle_info,
                  resample_to=None,
-                 resample_subject_to=False,
+                 resample_subject_to=None,
                  keep_in_memory=False):
         if not (isinstance(bundle_info, dict)):
             raise TypeError((

--- a/AFQ/data/fetch.py
+++ b/AFQ/data/fetch.py
@@ -405,6 +405,8 @@ def read_resample_roi(roi, resample_to=None, threshold=False):
     nibabel image class instance that contains the binary ROI resampled into
     the requested space.
     """
+    logger = logging.getLogger('AFQ')
+
     if isinstance(roi, str):
         roi = nib.load(roi)
 
@@ -414,7 +416,16 @@ def read_resample_roi(roi, resample_to=None, threshold=False):
     if isinstance(resample_to, str):
         resample_to = nib.load(resample_to)
 
-    if resample_to is False or np.allclose(resample_to.affine, roi.affine):
+    if np.allclose(resample_to.affine, roi.affine):
+        logger.info("Resampling skipped as affines already match.")
+        return roi
+
+    if resample_to is False:
+        if not np.allclose(resample_to.affine, roi.affine):
+            logger.warning(
+                "Resampling set to False in case where affines "
+                "do not match. This is likely due to subject space ROIs"
+                " not being in the right space.")
         return roi
 
     as_array = resample(

--- a/AFQ/data/fetch.py
+++ b/AFQ/data/fetch.py
@@ -416,16 +416,16 @@ def read_resample_roi(roi, resample_to=None, threshold=False):
     if isinstance(resample_to, str):
         resample_to = nib.load(resample_to)
 
-    if np.allclose(resample_to.affine, roi.affine):
-        logger.info("Resampling skipped as affines already match.")
-        return roi
-
     if resample_to is False:
         if not np.allclose(resample_to.affine, roi.affine):
             logger.warning(
                 "Resampling set to False in case where affines "
                 "do not match. This is likely due to subject space ROIs"
                 " not being in the right space.")
+        return roi
+
+    if np.allclose(resample_to.affine, roi.affine):
+        logger.info("Resampling skipped as affines already match.")
         return roi
 
     as_array = resample(

--- a/AFQ/data/fetch.py
+++ b/AFQ/data/fetch.py
@@ -417,11 +417,6 @@ def read_resample_roi(roi, resample_to=None, threshold=False):
         resample_to = nib.load(resample_to)
 
     if resample_to is False:
-        if not np.allclose(resample_to.affine, roi.affine):
-            logger.warning(
-                "Resampling set to False in case where affines "
-                "do not match. This is likely due to subject space ROIs"
-                " not being in the right space.")
         return roi
 
     if np.allclose(resample_to.affine, roi.affine):

--- a/AFQ/recognition/criteria.py
+++ b/AFQ/recognition/criteria.py
@@ -334,6 +334,21 @@ def run_bundle_rec_plan(
         mapping,
         img.affine,
         apply_to_recobundles=True))
+
+    def check_space(roi):
+        if not np.allclose(img.affine, roi.affine):
+            logger.warning(
+                "Resampling set to False in case where affines "
+                "do not match. This is likely due to subject space ROIs"
+                " not being in the right space. This found for bundle "
+                f"{bundle_name}")
+
+    apply_to_roi_dict(
+        bundle_def,
+        check_space,
+        dry_run=True,
+        apply_to_prob_map=True)
+
     apply_to_roi_dict(
         bundle_def,
         lambda roi_img: nib.Nifti1Image(

--- a/AFQ/tasks/data.py
+++ b/AFQ/tasks/data.py
@@ -1081,8 +1081,7 @@ def brain_mask(b0, brain_mask_definition=None):
 
 
 @pimms.calc("bundle_dict", "reg_template", "tmpl_name")
-def get_bundle_dict(segmentation_params,
-                    brain_mask, b0,
+def get_bundle_dict(brain_mask, b0,
                     bundle_info=None, reg_template_spec="mni_T1",
                     reg_template_space_name="mni"):
     """
@@ -1156,6 +1155,9 @@ def get_bundle_dict(segmentation_params,
         bundle_dict = abd.BundleDict(
             bundle_info,
             resample_to=reg_template)
+
+    if bundle_dict.resample_subject_to is None:
+        bundle_dict.resample_subject_to = b0
 
     return bundle_dict, reg_template, reg_template_space_name
 


### PR DESCRIPTION
Adds appropriate warnings for subject space resampling, as well as the option to automatically resample subject space ROIs.

By default, does not resample subject space ROIs and throws a warning if they seem like they are not in the right space.

This is the same as the old default, I just added a warning.