### PR TITLE
[FIX] cast certain user inputs before calling GPU Streamlines

### DIFF
--- a/AFQ/tractography/gputractography.py
+++ b/AFQ/tractography/gputractography.py
@@ -137,8 +137,8 @@ def gpu_track(data, gtab, seed_img, stop_img,
         model_type,
         radians(max_angle),
         1.0,
-        stop_threshold,
-        step_size,
+        float(stop_threshold),
+        float(step_size),
         0.25,  # relative peak threshold
         radians(45),  # min separation angle
         np.ascontiguousarray(data).astype(np.float64),

--- a/AFQ/tractography/tractography.py
+++ b/AFQ/tractography/tractography.py
@@ -22,9 +22,9 @@ from AFQ.tractography.utils import gen_seeds, get_percentile_threshold
 
 
 def track(params_file, directions="prob", max_angle=30., sphere=None,
-          seed_mask=None, seed_threshold=0, thresholds_as_percentages=False,
+          seed_mask=None, seed_threshold=0.5, thresholds_as_percentages=False,
           n_seeds=1, random_seeds=False, rng_seed=None, stop_mask=None,
-          stop_threshold=0, step_size=0.5, minlen=50, maxlen=250,
+          stop_threshold=0.5, step_size=0.5, minlen=50, maxlen=250,
           odf_model="CSD", basis_type="descoteaux07", legacy=True,
           tracker="local", trx=False):
     """


### PR DESCRIPTION
Also changes default stop/seed threshold to 0.5 in case where a stop/seed mask is provided but no threshold is provided.