### PR TITLE
[WIP/ENH] Retooling Multishell pipeline

### DIFF
--- a/AFQ/api/utils.py
+++ b/AFQ/api/utils.py
@@ -143,7 +143,10 @@ def export_all_helper(api_afq_object, xforms, indiv, viz):
     api_afq_object.export("median_bundle_lengths")
     api_afq_object.export("profiles")
     api_afq_object.export("seed_thresh")
-    api_afq_object.export("stop_thresh")
+    try:
+        api_afq_object.export("stop_thresh")
+    except ValueError:
+        pass
 
     if viz:
         try:

--- a/AFQ/models/asym_filtering.py
+++ b/AFQ/models/asym_filtering.py
@@ -1,0 +1,393 @@
+# -*- coding: utf-8 -*-
+# Original source: github.com/scilus/scilpy
+# Copyright (c) 2012-- Sherbrooke Connectivity Imaging Lab [SCIL], Université de Sherbrooke.
+# Licensed under the MIT License (https://opensource.org/licenses/MIT).
+# Modified by John Kruper for pyAFQ
+# OpenCL and cosine filtering removed
+
+import numpy as np
+import logging
+from dipy.reconst.shm import sh_to_sf_matrix
+from dipy.data import get_sphere
+
+
+__all__ = ["unified_filtering"]
+
+
+def _get_sh_order_and_fullness(ncoeffs):
+    """
+    Get the order of the SH basis from the number of SH coefficients
+    as well as a boolean indicating if the basis is full.
+    """
+    # the two curves (sym and full) intersect at ncoeffs = 1, in what
+    # case both bases correspond to order 1.
+    sym_order = (-3.0 + np.sqrt(1.0 + 8.0 * ncoeffs)) / 2.0
+    if sym_order.is_integer():
+        return sym_order, False
+    full_order = np.sqrt(ncoeffs) - 1.0
+    if full_order.is_integer():
+        return full_order, True
+    raise ValueError('Invalid number of coefficients for SH basis.')
+
+
+def unified_filtering(sh_data, sphere,
+                      sh_basis='descoteaux07', is_legacy=False,
+                      sigma_spatial=1.0, sigma_align=0.8,
+                      sigma_angle=None, rel_sigma_range=0.2,
+                      win_hwidth=None, exclude_center=False):
+    """
+    Unified asymmetric filtering as described in [1].
+
+    Parameters
+    ----------
+    sh_data: ndarray
+        SH coefficients image.
+    sphere: str or DIPY sphere
+        Name of the DIPY sphere to use for SH to SF projection.
+    sh_basis: str
+        SH basis definition used for input and output SH image.
+        One of 'descoteaux07' or 'tournier07'.
+        Default: 'descoteaux07'.
+    is_legacy: bool
+        Whether the legacy SH basis definition should be used.
+        Default: False.
+    sigma_spatial: float or None
+        Standard deviation of spatial filter. Can be None to replace
+        by mean filter, in what case win_hwidth must be given.
+    sigma_align: float or None
+        Standard deviation of alignment filter. `None` disables
+        alignment filtering.
+    sigma_angle: float or None
+        Standard deviation of the angle filter. `None` disables
+        angle filtering.
+    rel_sigma_range: float or None
+        Standard deviation of the range filter, relative to the
+        range of SF amplitudes. `None` disables range filtering.
+    disable_spatial: bool, optional
+        Replace gaussian filter by a mean filter for spatial filter.
+        The value from `sigma_spatial` is still used for setting the
+        size of the filtering window.
+    win_hwidth: int, optional
+        Half-width of the filtering window. When None, the
+        filtering window half-width is given by (6*sigma_spatial + 1).
+    exclude_center: bool, optional
+        Assign a weight of 0 to the center voxel of the filter.
+
+    References
+    ----------
+    [1] Poirier and Descoteaux, 2024, "A Unified Filtering Method for
+        Estimating Asymmetric Orientation Distribution Functions",
+        Neuroimage, https://doi.org/10.1016/j.neuroimage.2024.120516
+    """
+    if sigma_spatial is None and win_hwidth is None:
+        raise ValueError('sigma_spatial and win_hwidth cannot both be None')
+
+    if isinstance(sphere, str):
+        sphere = get_sphere(name=sphere)
+
+    if sigma_spatial is not None:
+        if sigma_spatial <= 0.0:
+            raise ValueError('sigma_spatial cannot be <= 0.')
+        # calculate half-width from sigma_spatial
+        half_width = int(round(3 * sigma_spatial))
+    if sigma_align is not None:
+        if sigma_align <= 0.0:
+            raise ValueError('sigma_align cannot be <= 0.')
+    if sigma_angle is not None:
+        if sigma_angle <= 0.0:
+            raise ValueError('sigma_align cannot be <= 0.')
+
+    sh_order, full_basis = _get_sh_order_and_fullness(sh_data.shape[-1])
+
+    # overwrite half-width if win_hwidth is supplied
+    if win_hwidth is not None:
+        half_width = win_hwidth
+
+    # filter shape computed from half_width
+    filter_shape = (half_width * 2 + 1, half_width * 2 + 1, half_width * 2 + 1)
+
+    # build filters
+    uv_filter = _unified_filter_build_uv(sigma_angle, sphere)
+    nx_filter = _unified_filter_build_nx(filter_shape, sigma_spatial,
+                                         sigma_align, sphere, exclude_center)
+
+    B = sh_to_sf_matrix(sphere, sh_order, sh_basis, full_basis,
+                        legacy=is_legacy, return_inv=False)
+    _, B_inv = sh_to_sf_matrix(sphere, sh_order, sh_basis, True,
+                               legacy=is_legacy, return_inv=True)
+
+    # compute "real" sigma_range scaled by sf amplitudes
+    # if rel_sigma_range is supplied
+    sigma_range = None
+    if rel_sigma_range is not None:
+        if rel_sigma_range <= 0.0:
+            raise ValueError('sigma_rangel cannot be <= 0.')
+        sigma_range = rel_sigma_range * _get_sf_range(sh_data, B)
+
+    return _unified_filter_call_python(sh_data, nx_filter, uv_filter,
+                                       sigma_range, B, B_inv, sphere)
+
+
+def _unified_filter_build_uv(sigma_angle, sphere):
+    """
+    Build the angle filter, weighted on angle between current direction u
+    and neighbour direction v.
+
+    Parameters
+    ----------
+    sigma_angle: float
+        Standard deviation of filter. Values at distances greater than
+        sigma_angle are clipped to 0 to reduce computation time.
+    sphere: DIPY sphere
+        Sphere used for sampling the SF.
+
+    Returns
+    -------
+    weights: ndarray
+        Angle filter of shape (N_dirs, N_dirs).
+    """
+    directions = sphere.vertices
+    if sigma_angle is not None:
+        dot = directions.dot(directions.T)
+        x = np.arccos(np.clip(dot, -1.0, 1.0))
+        weights = _evaluate_gaussian_distribution(x, sigma_angle)
+        mask = x > (3.0 * sigma_angle)
+        weights[mask] = 0.0
+        weights /= np.sum(weights, axis=-1)
+    else:
+        weights = np.eye(len(directions))
+    return weights
+
+
+def _unified_filter_build_nx(filter_shape, sigma_spatial, sigma_align,
+                             sphere, exclude_center):
+    """
+    Build the combined spatial and alignment filter.
+
+    Parameters
+    ----------
+    filter_shape: tuple
+        Dimensions of filtering window.
+    sigma_spatial: float or None
+        Standard deviation of spatial filter. None disables Gaussian
+        weighting for spatial filtering.
+    sigma_align: float or None
+        Standard deviation of the alignment filter. None disables Gaussian
+        weighting for alignment filtering.
+    sphere: DIPY sphere
+        Sphere for SH to SF projection.
+    exclude_center: bool
+        Whether the center voxel is included in the neighbourhood.
+
+    Returns
+    -------
+    weights: ndarray
+        Combined spatial + alignment filter of shape (W, H, D, N) where
+        N is the number of sphere directions.
+    """
+    directions = sphere.vertices.astype(np.float32)
+
+    grid_directions = _get_window_directions(filter_shape).astype(np.float32)
+    distances = np.linalg.norm(grid_directions, axis=-1)
+    grid_directions[distances > 0] = grid_directions[distances > 0] /\
+        distances[distances > 0][..., None]
+
+    if sigma_spatial is None:
+        w_spatial = np.ones(filter_shape)
+    else:
+        w_spatial = _evaluate_gaussian_distribution(distances, sigma_spatial)
+
+    if sigma_align is None:
+        w_align = np.ones(np.append(filter_shape, (len(directions),)))
+    else:
+        cos_theta = np.clip(grid_directions.dot(directions.T), -1.0, 1.0)
+        theta = np.arccos(cos_theta)
+        theta[filter_shape[0] // 2,
+              filter_shape[1] // 2,
+              filter_shape[2] // 2] = 0.0
+        w_align = _evaluate_gaussian_distribution(theta, sigma_align)
+
+    # resulting filter
+    w = w_spatial[..., None] * w_align
+
+    if exclude_center:
+        w[filter_shape[0] // 2,
+          filter_shape[1] // 2,
+          filter_shape[2] // 2] = 0.0
+
+    # normalize and return
+    w /= np.sum(w, axis=(0, 1, 2), keepdims=True)
+    return w
+
+
+def _get_sf_range(sh_data, B_mat):
+    """
+    Get the range of SF amplitudes for input `sh_data`.
+
+    Parameters
+    ----------
+    sh_data: ndarray
+        Spherical harmonics coefficients image.
+    B_mat: ndarray
+        SH to SF projection matrix.
+
+    Returns
+    -------
+    sf_range: float
+        Range of SF amplitudes.
+    """
+    sf = np.array([np.dot(i, B_mat) for i in sh_data],
+                  dtype=sh_data.dtype)
+    sf[sf < 0.0] = 0.0
+    sf_max = np.max(sf)
+    sf_min = np.min(sf)
+    return sf_max - sf_min
+
+
+def _unified_filter_call_python(sh_data, nx_filter, uv_filter, sigma_range,
+                                B_mat, B_inv, sphere):
+    """
+    Run filtering using pure python implementation.
+
+    Parameters
+    ----------
+    sh_data: ndarray
+        Input SH data.
+    nx_filter: ndarray
+        Combined spatial and alignment filter.
+    uv_filter: ndarray
+        Angle filter.
+    sigma_range: float or None
+        Standard deviation of range filter. None disables range filtering.
+    B_mat: ndarray
+        SH to SF projection matrix.
+    B_inv: ndarray
+        SF to SH projection matrix.
+    sphere: DIPY sphere
+        Sphere for SH to SF projection.
+
+    Returns
+    -------
+    out_sh: ndarray
+        Filtered output as SH coefficients.
+    """
+    nb_sf = len(sphere.vertices)
+    mean_sf = np.zeros(sh_data.shape[:-1] + (nb_sf,))
+
+    # Apply filter to each sphere vertice
+    for u_sph_id in range(nb_sf):
+        if u_sph_id % 20 == 0:
+            logging.info('Processing direction: {}/{}'
+                         .format(u_sph_id, nb_sf))
+        mean_sf[..., u_sph_id] = _correlate(sh_data, nx_filter, uv_filter,
+                                            sigma_range, u_sph_id, B_mat)
+
+    out_sh = np.array([np.dot(i, B_inv) for i in mean_sf],
+                      dtype=sh_data.dtype)
+    return out_sh
+
+
+def _correlate(sh_data, nx_filter, uv_filter, sigma_range, u_index, B_mat):
+    """
+    Apply the filters to the SH image for the sphere direction
+    described by `u_index`.
+
+    Parameters
+    ----------
+    sh_data: ndarray
+        Input SH coefficients.
+    nx_filter: ndarray
+        Combined spatial and alignment filter.
+    uv_filter: ndarray
+        Angle filter.
+    sigma_range: float or None
+        Standard deviation of range filter. None disables range filtering.
+    u_index: int
+        Index of the current sphere direction to process.
+    B_mat: ndarray
+        SH to SF projection matrix.
+
+    Returns
+    -------
+    out_sf: ndarray
+        Output SF amplitudes along the direction described by `u_index`.
+    """
+    v_indices = np.flatnonzero(uv_filter[u_index])
+    nx_filter = nx_filter[..., u_index]
+    h_w, h_h, h_d = nx_filter.shape[:3]
+    half_w, half_h, half_d = h_w // 2, h_h // 2, h_d // 2
+    out_sf = np.zeros(sh_data.shape[:3])
+    sh_data = np.pad(sh_data, ((half_w, half_w),
+                               (half_h, half_h),
+                               (half_d, half_d),
+                               (0, 0)))
+
+    sf_u = np.dot(sh_data, B_mat[:, u_index])
+    sf_v = np.dot(sh_data, B_mat[:, v_indices])
+    uv_filter = uv_filter[u_index, v_indices]
+
+    _get_range = _evaluate_gaussian_distribution\
+        if sigma_range is not None else lambda x, _: np.ones_like(x)
+
+    for ii in range(out_sf.shape[0]):
+        for jj in range(out_sf.shape[1]):
+            for kk in range(out_sf.shape[2]):
+                a = sf_v[ii:ii + h_w, jj:jj + h_h, kk:kk + h_d]
+                b = sf_u[ii + half_w, jj + half_h, kk + half_d]
+                x_range = a - b
+                range_filter = _get_range(x_range, sigma_range)
+
+                # the resulting filter for the current voxel and v_index
+                res_filter = range_filter * nx_filter[..., None]
+                res_filter =\
+                    res_filter * np.reshape(uv_filter,
+                                            (1, 1, 1, len(uv_filter)))
+                out_sf[ii, jj, kk] = np.sum(
+                    sf_v[ii:ii + h_w, jj:jj + h_h, kk:kk + h_d] * res_filter)
+                out_sf[ii, jj, kk] /= np.sum(res_filter)
+
+    return out_sf
+
+
+def _evaluate_gaussian_distribution(x, sigma):
+    """
+    1-dimensional 0-centered Gaussian distribution
+    with standard deviation sigma.
+
+    Parameters
+    ----------
+    x: ndarray or float
+        Points where the distribution is evaluated.
+    sigma: float
+        Standard deviation.
+
+    Returns
+    -------
+    out: ndarray or float
+        Values at x.
+    """
+    assert sigma > 0.0, "Sigma must be greater than 0."
+    cnorm = 1.0 / sigma / np.sqrt(2.0 * np.pi)
+    return cnorm * np.exp(-x**2 / 2 / sigma**2)
+
+
+def _get_window_directions(shape):
+    """
+    Get directions from center voxel to all neighbours
+    for a window of given shape.
+
+    Parameters
+    ----------
+    shape: tuple
+        Dimensions of the window.
+
+    Returns
+    -------
+    grid: ndarray
+        Grid containing the direction from the center voxel to
+        the current position for all positions inside the window.
+    """
+    grid = np.indices(shape)
+    grid = np.moveaxis(grid, 0, -1)
+    grid = grid - np.asarray(shape) // 2
+    return grid

--- a/AFQ/models/msmt.py
+++ b/AFQ/models/msmt.py
@@ -1,0 +1,272 @@
+import numpy as np
+from scipy.optimize import minimize
+from numba import njit, prange, config, set_num_threads
+from tqdm import tqdm
+
+from dipy.reconst.mcsd import MSDeconvFit
+
+
+config.THREADING_LAYER = 'workqueue'
+
+
+__all__ = ["fit"]
+
+
+# CPU implementation of primal-dual Interior Point method
+# for convex quadratic constrained optimization (QP)
+# Specifically, ||Rx-d||_2 where Ax>=b
+# parallelized to solve 10s-100s of thousands of QPs
+# ultimately used to fit MSMT CSD
+@njit(fastmath=True)
+def solve_qp(Rt, R_pinv, G, A, b, x0,
+             d, max_iter, tol):
+    '''
+    Solves 1/2*x^t*G*x+(Rt*d)^t*x given Ax>=b
+    In MSMT, G, R, A, b are the same across voxels,
+    but there are different d for different voxels.
+    This fact is not used currently. So this is a more general
+    batched CLS QP solver.
+
+    Let:
+    c=(Rt*d)^t
+    L = diag(l)
+    Y = diag(y)
+    mu as centering parameter that tends to 0 with iteration number.
+
+    Set up with interior points, this is reformulated to:
+    | G  0 -A.T | |dx|   |0 |   | G*x-A.T*l+c |
+    | A -I  0   | |dy| = |0 | - | A*x-y-b     |
+    | 0  L  Y   | |dl|   |mu|   | YL          |
+
+    This reduces to:
+    |G -A.T| |dx| = | -G*x-A.T*l+c          |
+    |A Y\L | |dl|   | -(A*x-y-b) + (-y+mu/l)|
+    with dy = A*dx+(A*x-y-b)
+
+    Solving for dx, dl:
+    (G+A.T*(Y\L)*A)*dx = -G*x-A.T*l+c
+    dl = (Y\L)*(-(A*x-y-b) + (-y+mu/l) - A*dx)
+
+    So, the tricky part is solving for dx.
+    However, note that G+A.T*(Y\L)*A is hermitian positive semidefinite.
+    So, it can be solved using conjugate gradients.
+    This is done every iteration and is the longest part of the calculation.
+    '''
+
+    n = A.shape[1]
+    m = A.shape[0]
+
+    # First check if naive solution satisfies constraints
+    x = R_pinv @ d
+    if np.all(A @ x - b >= -tol):
+        return True, x
+
+    c = Rt @ d
+
+    x = x0.copy()
+    y = np.ones(m)
+    l = np.ones(m)
+    dx = np.zeros(n)
+    dy = np.zeros(m)
+    dl = np.zeros(m)
+
+    tau = 0.9
+    shur_regularization = 1e-6
+    for _ in range(max_iter):
+        mu = (y @ l) / m
+
+        # Predictor step
+        Z = safe_divide_vec(l, y)
+        dy = A @ x - y - b
+        rhs2 = -dy - y
+        rhs1l = -(G @ x - A.T @ l + c)
+        rhs1 = rhs1l + A.T @ (Z * rhs2)
+
+        schur = G + A.T @ np.diag(Z) @ A
+        schur += np.eye(schur.shape[0]) * shur_regularization
+        schur_diag = np.diag(schur)
+
+        # dx = cholesky_solve(schur, rhs1)
+        dx = conjugate_gradient_precond(
+            schur, rhs1, dx,
+            schur_diag, 5, 1e-4 * tol)
+        dl_aff = Z * (rhs2 - A @ dx)
+        dy_aff = dy + A @ dx
+
+        alpha_aff_pri = 1.0
+        alpha_aff_dual = 1.0
+        for ii in range(m):
+            if dy_aff[ii] < 0:
+                alpha_aff_pri = min(alpha_aff_pri, -y[ii] / dy_aff[ii])
+            if dl_aff[ii] < 0:
+                alpha_aff_dual = min(alpha_aff_dual, -l[ii] / dl_aff[ii])
+        alpha_aff = min(tau * alpha_aff_pri, tau * alpha_aff_dual)
+
+        mu_aff = ((y + alpha_aff * dy_aff) @ (l + alpha_aff * dl_aff)) / m
+        sigma = (mu_aff / mu) ** 3
+        mu = sigma * mu
+
+        # Main corrector step
+        rhs2 = -dy + (-y + safe_divide_vec(mu, l))
+        rhs1 = rhs1l + A.T @ (Z * rhs2)
+
+        # dx = cholesky_solve(schur, rhs1)
+        dx = conjugate_gradient_precond(
+            schur, rhs1, dx,
+            schur_diag, max_iter, max(tol, 1e-2 * mu))
+        dl = Z * (rhs2 - A @ dx)
+        dy += A @ dx
+
+        beta = 1.0
+        sigma = 1.0
+        for ii in range(m):
+            if dy[ii] < 0 and dy[ii] * sigma < -y[ii]:
+                sigma = -y[ii] / dy[ii]
+            if dl[ii] < 0 and dl[ii] * beta < -l[ii]:
+                beta = -l[ii] / dl[ii]
+        beta *= tau
+        sigma *= tau
+        alpha = min(beta, sigma)
+
+        x += alpha * dx
+        y += alpha * dy
+        l += alpha * dl
+
+        if (alpha * np.sum(np.abs(dx)) < n * tol
+            and alpha * np.sum(np.abs(dy)) < m * tol
+                and alpha * np.sum(np.abs(dl)) < m * tol):
+            if np.all(A @ x - b >= -tol):
+                return True, x
+            else:
+                return False, x0
+
+    return False, x0
+
+
+@njit(fastmath=True)
+def conjugate_gradient_precond(A, b, x, diag, max_iter, tol):
+    """
+    Solves A x = b with Jacobi preconditioner (diag) using Conjugate Gradient.
+
+    Args:
+        A : 2D np.ndarray, symmetric positive-definite matrix
+        b : 1D np.ndarray, RHS vector
+        x : 1D np.ndarray, initial guess (will be modified in-place)
+        diag : 1D np.ndarray, diagonal of preconditioner (Jacobi)
+        max_iter : int, maximum number of iterations
+        tol : float, stopping threshold
+
+    Returns:
+        x : Updated solution
+    """
+    r = b - A @ x
+    r /= diag
+    p = r.copy()
+    rs_old = np.dot(r * r, diag)
+
+    for _ in range(max_iter):
+        Ap = A @ p
+        alpha = rs_old / np.dot(p, Ap)
+        x += alpha * p
+        r -= alpha * Ap / diag
+        rs_new = np.dot(r * r, diag)
+        if rs_new < tol:
+            break
+        beta = rs_new / rs_old
+        p = r + beta * p
+        rs_old = rs_new
+
+    return x
+
+
+@njit(fastmath=True)
+def safe_divide_vec(numer, denom):
+    safe_divisor = 1e-6  # Used to avoid division by zero
+    return numer / np.where(
+        np.abs(denom) < safe_divisor,
+        np.sign(denom) * safe_divisor, denom)
+
+
+def find_analytic_center(A, b, x0):
+    """Find the analytic center using scipy.optimize.minimize"""
+    cons = {'type': 'ineq', 'fun': lambda x: A @ x - b}
+    result = minimize(
+        lambda x: 1e-3 * np.linalg.norm(x)**2 - np.sum(np.log(A @ x - b)),
+        x0,
+        constraints=cons,
+        method='SLSQP'
+    )
+    return result.x
+
+
+@njit(parallel=True, fastmath=True)
+def _process_slice(slice_data, slice_mask, slice_results,
+                   Rt, R_pinv,
+                   G, A, b, x0,
+                   max_iter, tol):
+    for j in prange(slice_data.shape[0]):
+        x_prev = x0.copy()
+        for k in range(slice_data.shape[1]):
+            if slice_mask[j, k]:
+                # previous values warm start next solver
+                # More complicated warm starts are slower
+                x_prev = np.clip(x_prev, -1.0, 1.0)
+                success, x_prev = solve_qp(
+                    Rt, R_pinv, G, A, b,
+                    x_prev,
+                    slice_data[j, k],
+                    max_iter, tol)
+
+                if success:
+                    slice_results[j, k] = x_prev
+                else:
+                    slice_results[j, k] = np.zeros(A.shape[1])
+            else:
+                slice_results[j, k] = np.zeros(A.shape[1])
+
+
+def fit(self, data, mask=None, max_iter=1e6, tol=1e-6, n_threads=None):
+    if n_threads is not None:
+        set_num_threads(n_threads)
+
+    m, n = self.fitter._reg.shape
+    coeff = np.zeros((*data.shape[:3], n), dtype=np.float64)
+    if mask is None:
+        mask = np.ones(data.shape[:3], dtype=bool)
+
+    R = np.ascontiguousarray(self.fitter._X, dtype=np.float64)
+    A = np.ascontiguousarray(self.fitter._reg, dtype=np.float64)
+    b = np.zeros(A.shape[0], dtype=np.float64)
+
+    # Normalize constraints
+    for i in range(A.shape[0]):
+        A[i] /= np.linalg.norm(A[i])
+
+    Q = R.T @ R
+    # Q += 1e-1 * np.eye(n)  # Strong Regularization # TODO
+    x0 = np.linalg.pinv(A) @ np.ones(A.shape[0])
+    x0 = find_analytic_center(A, b, x0)
+
+    Rt = -R.T
+    R_pinv = np.linalg.pinv(R).astype(np.float64)
+    data = np.ascontiguousarray(data, dtype=np.float64)
+
+    Rt = np.ascontiguousarray(Rt, dtype=np.float64)
+    R_pinv = np.ascontiguousarray(R_pinv, dtype=np.float64)
+    Q = np.ascontiguousarray(Q, dtype=np.float64)
+    A = np.ascontiguousarray(A, dtype=np.float64)
+    b = np.ascontiguousarray(b, dtype=np.float64)
+    x0 = np.ascontiguousarray(x0, dtype=np.float64)
+
+    for ii in tqdm(range(data.shape[0])):
+        _process_slice(
+            data[ii], mask[ii], coeff[ii],
+            Rt,
+            R_pinv,
+            Q,
+            A,
+            b,
+            x0,
+            max_iter, tol)
+
+    return MSDeconvFit(self, coeff, None)

--- a/AFQ/tasks/data.py
+++ b/AFQ/tasks/data.py
@@ -1,10 +1,15 @@
 import nibabel as nib
 import numpy as np
 import logging
+from tqdm import tqdm
 
 from dipy.io.gradients import read_bvals_bvecs
 import dipy.core.gradients as dpg
-from dipy.data import default_sphere
+from dipy.data import default_sphere, get_sphere
+
+from scipy.signal import find_peaks, peak_widths
+from scipy.ndimage import gaussian_filter1d
+from scipy.special import erf
 
 import pimms
 
@@ -16,6 +21,13 @@ from dipy.reconst.gqi import GeneralizedQSamplingModel
 from dipy.reconst.rumba import RumbaSDModel, RumbaFit
 from dipy.reconst import shm
 from dipy.reconst.dki_micro import axonal_water_fraction
+from dipy.segment.tissue import compute_directional_average
+from dipy.reconst.mcsd import (
+    MultiShellDeconvModel,
+    mask_for_response_msmt,
+    multi_shell_fiber_response,
+    response_from_mask_msmt)
+from dipy.core.gradients import unique_bvals_tolerance
 
 from AFQ.tasks.decorators import as_file, as_img, as_fit_deriv
 from AFQ.tasks.utils import get_fname, with_name, str_to_desc
@@ -33,8 +45,10 @@ from AFQ.models.csd import CsdNanResponseError
 from AFQ.models.dki import _fit as dki_fit_model
 from AFQ.models.dti import _fit as dti_fit_model
 from AFQ.models.fwdti import _fit as fwdti_fit_model
+from AFQ.models.msmt import fit as msmt_fit
 from AFQ.models.QBallTP import (
     extract_odf, anisotropic_index, anisotropic_power)
+from AFQ.models.asym_filtering import unified_filtering
 
 
 logger = logging.getLogger('AFQ')
@@ -86,26 +100,27 @@ def get_data_gtab(dwi_data_file, bval_file, bvec_file, min_bval=None,
         bvals = bvals[valid_b]
         bvecs = bvecs[valid_b]
     gtab = dpg.gradient_table(
-        bvals = bvals, bvecs = bvecs,
-        b0_threshold = b0_threshold)
+        bvals=bvals, bvecs=bvecs,
+        b0_threshold=b0_threshold)
     img = nib.Nifti1Image(data, img.affine)
     return data, gtab, img, img.affine
 
 
 @pimms.calc("b0")
 @as_file('_b0ref.nii.gz')
+@as_img
 def b0(dwi, gtab):
     """
     full path to a nifti file containing the mean b0
     """
     mean_b0 = np.mean(dwi.get_fdata()[..., gtab.b0s_mask], -1)
-    mean_b0_img = nib.Nifti1Image(mean_b0, dwi.affine)
     meta = dict(b0_threshold=gtab.b0_threshold)
-    return mean_b0_img, meta
+    return mean_b0, meta
 
 
 @pimms.calc("masked_b0")
 @as_file('_desc-masked_b0ref.nii.gz')
+@as_img
 def b0_mask(b0, brain_mask):
     """
     full path to a nifti file containing the
@@ -117,11 +132,259 @@ def b0_mask(b0, brain_mask):
     masked_data = img.get_fdata()
     masked_data[~brain_mask] = 0
 
-    masked_b0_img = nib.Nifti1Image(masked_data, img.affine)
     meta = dict(
         source=b0,
         masked=True)
-    return masked_b0_img, meta
+    return masked_data, meta
+
+
+@pimms.calc("dam_params")
+@as_file(suffix='_model-dam_param-slopeintercept_dwimap.nii.gz',
+         subfolder="models")
+@as_img
+def dam_fit(data, gtab, masked_b0,
+            dam_low_signal_thresh=50):
+    """
+    direction-averaged signal map (DAM) [1] slope and intercept
+
+    Parameters
+    ----------
+    dam_low_signal_thresh : float, optional
+        The threshold below which a voxel is considered to have low signal.
+        Default: 50
+
+    References
+    ----------
+    .. [1] Cheng, H., Newman, S., Afzali, M., Fadnavis, S.,
+            & Garyfallidis, E. (2020). Segmentation of the brain using
+            direction-averaged signal of DWI images. 
+            Magnetic Resonance Imaging, 69, 1-7. Elsevier. 
+            https://doi.org/10.1016/j.mri.2020.02.010
+    """
+    # Precompute unique b-values, masks
+    unique_bvals = np.unique(gtab.bvals)
+    if len(unique_bvals) <= 2:
+        raise ValueError(("Insufficient unique b-values for fitting DAM. "
+                         "Note, DAM requires multi-shell data"))
+    masks = gtab.bvals[:, np.newaxis] == unique_bvals[np.newaxis, 1:]
+
+    b0_data = nib.load(masked_b0).get_fdata()
+
+    # If the mean signal for b=0 is too low,
+    # set those voxels to 0 for both P and V
+    valid_voxels = b0_data >= dam_low_signal_thresh
+
+    params_map = np.zeros((*data.shape[:-1], 2))
+    logger.info("Fitting directional average map (DAM)...")
+    for idx in tqdm(range(data.shape[0] * data.shape[1] * data.shape[2])):
+        i, j, k = np.unravel_index(idx, data.shape[:-1])
+        if valid_voxels[i, j, k]:
+            aa, bb = compute_directional_average(
+                data[i, j, k, :],
+                gtab.bvals,
+                masks=masks,
+                b0_mask=gtab.b0s_mask,
+                s0_map=b0_data[i, j, k],
+                low_signal_threshold=dam_low_signal_thresh,
+            )
+            if aa > 0.01 and bb < 0:
+                params_map[i, j, k, 0] = aa
+                params_map[i, j, k, 1] = -bb
+
+    return params_map, dict(low_signal_thresh=dam_low_signal_thresh)
+
+
+@pimms.calc("dam_csf")
+@as_file(suffix='_model-dam_param-csf_probseg.nii.gz',
+         subfolder="models")
+@as_img
+def dam_csf(dam_params):
+    """
+    CSF probability map from DAM intercept
+    """
+    dam_intercept_data = nib.load(dam_params).get_fdata()[..., 1]
+    beta_values = dam_intercept_data.flatten()
+    beta_values = beta_values[beta_values != 0]
+
+    # Make a smoothed histogram
+    hist, bin_edges = np.histogram(beta_values, bins=200, density=True)
+    bin_centers = (bin_edges[:-1] + bin_edges[1:]) / 2
+    smoothed_hist = gaussian_filter1d(hist, sigma=2)
+
+    # Find the main peak
+    peaks, _ = find_peaks(smoothed_hist, height=0.1 * np.max(smoothed_hist))
+    if len(peaks) == 0:
+        raise ValueError((
+            "DAM intercept: No peaks found in the histogram, "
+            "required for DAM CSF estimate"))
+
+    main_peak_idx = peaks[np.argmax(smoothed_hist[peaks])]
+    main_peak_val = bin_centers[main_peak_idx]
+
+    # Find the threshold symmetric to 0 with respect to the peak center
+    threshold = 2 * main_peak_val
+
+    return dam_intercept_data > threshold, dict(
+        DAMParamsFile=dam_params,
+        threshold=threshold)
+
+
+@pimms.calc("dam_pseudot1")
+@as_file(suffix='_model-dam_param-pseudot1_dwimap.nii.gz',
+         subfolder="models")
+@as_img
+def dam_pseudot1(dam_params, dam_csf):
+    """
+    Pseudo T1 map from DAM fit
+    """
+    dam_slope_data = nib.load(dam_params).get_fdata()[..., 0]
+    dam_csf_data = nib.load(dam_csf).get_fdata()
+
+    dam_slope_min = np.percentile(
+        dam_slope_data[dam_slope_data != 0], 0.5)
+    dam_slope_data[dam_slope_data < dam_slope_min] = 0
+
+    dam_slope_max = np.percentile(
+        dam_slope_data[dam_slope_data != 0], 99.5)
+    dam_slope_data[dam_slope_data > dam_slope_max] = 0
+
+    dam_slope_data[dam_slope_data != 0] = dam_slope_max - \
+        dam_slope_data[dam_slope_data != 0]
+    pseudo_t1 = (1.0 - dam_csf_data) * dam_slope_data
+
+    return pseudo_t1, dict(source=dam_params)
+
+
+@pimms.calc("dki_csf")
+@as_file(suffix='_model-dki_param-csf_probseg.nii.gz',
+         subfolder="models")
+@as_img
+def dki_csf(dki_md):
+    """
+    CSF probability map from DKI MD inspired by [1]
+
+    References
+    ----------
+    .. [1] Cheng, H., Newman, S., Afzali, M., Fadnavis, S.,
+            & Garyfallidis, E. (2020). Segmentation of the brain using
+            direction-averaged signal of DWI images. 
+            Magnetic Resonance Imaging, 69, 1-7. Elsevier. 
+            https://doi.org/10.1016/j.mri.2020.02.010
+    """
+    dki_md_data = nib.load(dki_md).get_fdata()
+    beta_values = dki_md_data.flatten()
+    beta_values = beta_values[beta_values != 0]
+
+    # Make a smoothed histogram
+    hist, bin_edges = np.histogram(beta_values, bins=200, density=True)
+    bin_centers = (bin_edges[:-1] + bin_edges[1:]) / 2
+    smoothed_hist = gaussian_filter1d(hist, sigma=2)
+
+    # Find the main peak
+    peaks, _ = find_peaks(smoothed_hist, height=0.1 * np.max(smoothed_hist))
+    if len(peaks) == 0:
+        raise ValueError((
+            "DKI MD: No peaks found in the histogram, "
+            "required for DKI CSF estimate"))
+
+    main_peak_idx = peaks[np.argmax(smoothed_hist[peaks])]
+    main_peak_val = bin_centers[main_peak_idx]
+
+    # Estimate uncertainty in peak center location
+    # The FWHM of a Gaussian is 2.355*sigma, so sigma ≈ FWHM/2.355
+    width_results = peak_widths(
+        smoothed_hist, [main_peak_idx], rel_height=0.5)
+    peak_width_md = abs(
+        bin_centers[1] - bin_centers[0]) * width_results[0][0]
+    peak_sigma = peak_width_md / 2.355
+
+    # Find the threshold symmetric to 0 with respect to the peak center
+    main_peak_val = 2 * main_peak_val
+    peak_sigma = 2 * peak_sigma
+
+    dki_md_data[dki_md_data != 0] = \
+        0.5 * (1 + erf((dki_md_data[dki_md_data != 0] - main_peak_val)
+                       / (peak_sigma * np.sqrt(2))))
+
+    return dki_md_data, dict(
+        DKI_MD_source=dki_md,
+        main_peak_val=main_peak_val,
+        peak_sigma=peak_sigma)
+
+
+@pimms.calc("dki_wm")
+@as_file(suffix='_model-dki_param-wm_probseg.nii.gz',
+         subfolder="models")
+@as_img
+def dki_wm(dki_fa, dki_wm_ll=0.1, dki_gm_ul=0.3):
+    """
+    WM probability map from DKI FA
+
+    Parameters
+    ----------
+    dki_wm_ll : float, optional
+        Lower limit of FA in white matter to calculate probability mask.
+        Default: 0.1
+    dki_gm_ul : float, optional
+        Upper limit of FA in gray matter to calculate probability mask.
+        Default: 0.3
+    """
+    dki_fa_data = nib.load(dki_fa).get_fdata()
+
+    uncertain_slice = np.logical_and(
+        dki_fa_data > dki_wm_ll,
+        dki_fa_data <= dki_gm_ul)
+    wm_data = dki_fa_data.copy()
+    wm_data[dki_fa_data >= dki_gm_ul] = 1.0
+    wm_data[uncertain_slice] = (dki_fa_data[uncertain_slice] - dki_wm_ll) /\
+        (dki_gm_ul - dki_wm_ll)
+    wm_data[dki_fa_data < dki_wm_ll] = 0.0
+
+    return wm_data, dict(
+        DKI_FA_source=dki_fa,
+        dki_wm_ll=dki_wm_ll,
+        dki_gm_ul=dki_gm_ul)
+
+
+@pimms.calc("dki_gm")
+@as_file(suffix='_model-dki_param-gm_probseg.nii.gz',
+         subfolder="models")
+@as_img
+def dki_gm(dki_fa, dki_csf, dki_wm_ll=0.1, dki_gm_ul=0.3):
+    """
+    GM probability map from DKI FA
+
+    Parameters
+    ----------
+    dki_wm_ll : float, optional
+        Lower limit of FA in white matter to calculate probability mask.
+        Default: 0.1
+    dki_gm_ul : float, optional
+        Upper limit of FA in gray matter to calculate probability mask.
+        Default: 0.3
+    """
+    dki_fa_data = nib.load(dki_fa).get_fdata()
+    dki_csf_data = nib.load(dki_csf).get_fdata()
+
+    uncertain_slice = np.logical_and(
+        dki_fa_data > dki_wm_ll,
+        dki_fa_data <= dki_gm_ul)
+    gm_data = dki_fa_data.copy()
+    gm_data[dki_fa_data >= dki_gm_ul] = 0.0
+    gm_data[uncertain_slice] = (dki_gm_ul - dki_fa_data[uncertain_slice]) /\
+        (dki_gm_ul - dki_wm_ll)
+    gm_data[np.logical_and(
+        dki_fa_data < dki_wm_ll,
+        dki_fa_data != 0)] = 1.0
+
+    gm_data = gm_data - dki_csf_data  # Remove CSF contribution
+    gm_data[gm_data < 0.0] = 0.0
+
+    return gm_data, dict(
+        DKI_FA_source=dki_fa,
+        DKI_CSF_source=dki_csf,
+        dki_wm_ll=dki_wm_ll,
+        dki_gm_ul=dki_gm_ul)
 
 
 @pimms.calc("dti_tf")
@@ -286,6 +549,110 @@ def msdki_msk(msdki_tf):
     the MSDKI mean signal kurtosis
     """
     return msdki_tf.msk
+
+
+@pimms.calc("msmtcsd_params")
+@as_file(suffix='_model-msmtcsd_param-fod_dwimap.nii.gz',
+         subfolder="models")
+@as_img
+def msmt_params(brain_mask, gtab, data,
+                dki_wm, dki_gm, dki_csf,
+                msmt_sh_order=8,
+                msmt_fa_thr=0.7):
+    """
+    full path to a nifti file containing
+    parameters for the MSMT CSD fit
+
+    Parameters
+    ----------
+    msmt_sh_order : int, optional.
+        Spherical harmonic order to use for the MSMT CSD fit.
+        Default: 8
+    msmt_fa_thr : float, optional.
+        The threshold on the FA used to calculate the multi shell auto
+        response. Can be useful to reduce for baby subjects.
+        Default: 0.7
+
+    References
+    ----------
+    .. [1] B. Jeurissen, J.-D. Tournier, T. Dhollander, A. Connelly, 
+            and J. Sijbers. Multi-tissue constrained spherical
+            deconvolution for improved analysis of multi-shell diffusion
+            MRI data. NeuroImage, 103 (2014), pp. 411–426
+    """
+    mask =\
+        nib.load(brain_mask).get_fdata()
+
+    mask_wm, mask_gm, mask_csf = mask_for_response_msmt(
+        gtab,
+        data,
+        roi_radii=10,
+        wm_fa_thr=msmt_fa_thr,
+        gm_fa_thr=0.3,
+        csf_fa_thr=0.15,
+        gm_md_thr=0.001,
+        csf_md_thr=0.0032)
+    mask_wm *= nib.load(dki_wm).get_fdata() > 0.5
+    mask_gm *= nib.load(dki_gm).get_fdata() > 0.5
+    mask_csf *= nib.load(dki_csf).get_fdata() > 0.5
+    response_wm, response_gm, response_csf = response_from_mask_msmt(
+        gtab, data, mask_wm, mask_gm, mask_csf)
+    ubvals = unique_bvals_tolerance(gtab.bvals)
+    response_mcsd = multi_shell_fiber_response(
+        msmt_sh_order,
+        ubvals,
+        response_wm,
+        response_gm,
+        response_csf)
+
+    mcsd_model = MultiShellDeconvModel(gtab, response_mcsd)
+    logger.info("Fitting Multi-Shell CSD model...")
+    mcsd_fit = msmt_fit(mcsd_model, data, mask)
+
+    meta = dict(
+        SphericalHarmonicDegree=msmt_sh_order,
+        SphericalHarmonicBasis="DESCOTEAUX")
+    return mcsd_fit.shm_coeff, meta
+
+
+@pimms.calc("msmt_apm")
+@as_file(suffix='_model-msmtcsd_param-apm_dwimap.nii.gz',
+         subfolder="models")
+@as_img
+def msmt_apm(msmtcsd_params):
+    """
+    full path to a nifti file containing
+    the anisotropic power map
+    """
+    sh_coeff = nib.load(msmtcsd_params).get_fdata()
+    pmap = anisotropic_power(sh_coeff)
+    return pmap, dict(MSMTCSDParamsFile=msmtcsd_params)
+
+
+@pimms.calc("msmt_aodf")
+@as_file(suffix='_model-msmtcsd_param-aodf_dwimap.nii.gz',
+         subfolder="models")
+@as_img
+def msmt_aodf(msmtcsd_params):
+    """
+    full path to a nifti file containing
+    MSMT CSD ODFs filtered by unified filtering [1]
+
+    References
+    ----------
+    [1] Poirier and Descoteaux, 2024, "A Unified Filtering Method for
+        Estimating Asymmetric Orientation Distribution Functions",
+        Neuroimage, https://doi.org/10.1016/j.neuroimage.2024.120516
+    """
+    sh_coeff = nib.load(msmtcsd_params).get_fdata()
+
+    aodf = unified_filtering(
+        sh_coeff,
+        get_sphere(name="repulsion724"))
+
+    return aodf, dict(
+        MSMTCSDParamsFile=msmtcsd_params,
+        Sphere="repulsion724")
 
 
 @pimms.calc("csd_params")
@@ -997,6 +1364,42 @@ def dki_kfa(dki_tf):
     return dki_tf.kfa
 
 
+@pimms.calc("dki_cl")
+@as_file('_model-dki_param-cl_dwimap.nii.gz',
+         subfolder="models")
+@as_fit_deriv('DKI')
+def dki_cl(dki_tf):
+    """
+    full path to a nifti file containing
+    the DKI linearity file
+    """
+    return dki_tf.linearity
+
+
+@pimms.calc("dki_cp")
+@as_file('_model-dki_param-cp_dwimap.nii.gz',
+         subfolder="models")
+@as_fit_deriv('DKI')
+def dki_cp(dki_tf):
+    """
+    full path to a nifti file containing
+    the DKI planarity file
+    """
+    return dki_tf.planarity
+
+
+@pimms.calc("dki_cs")
+@as_file('_model-dki_param-cs_dwimap.nii.gz',
+         subfolder="models")
+@as_fit_deriv('DKI')
+def dki_cs(dki_tf):
+    """
+    full path to a nifti file containing
+    the DKI sphericity file
+    """
+    return dki_tf.sphericity
+
+
 @pimms.calc("dki_ga")
 @as_file(suffix='_model-dki_param-ga_dwimap.nii.gz',
          subfolder="models")
@@ -1172,8 +1575,10 @@ def get_data_plan(kwargs):
 
     data_tasks = with_name([
         get_data_gtab, b0, b0_mask, brain_mask,
+        dam_fit, dam_csf, dam_pseudot1,
         dti_fit, dki_fit, fwdti_fit, anisotropic_power_map,
         csd_anisotropic_index,
+        msmt_params, msmt_apm, msmt_aodf,
         dti_fa, dti_lt, dti_cfa, dti_pdd, dti_md, dki_kt, dki_lt, dki_fa,
         gq, gq_pmap, gq_ai, opdt_params, opdt_pmap, opdt_ai,
         csa_params, csa_pmap, csa_ai,
@@ -1182,6 +1587,8 @@ def get_data_plan(kwargs):
         dki_md, dki_awf, dki_mk, dki_kfa, dki_ga, dki_rd,
         dti_ga, dti_rd, dti_ad,
         dki_ad, dki_rk, dki_ak, dti_params, dki_params, fwdti_params,
+        dki_cl, dki_cp, dki_cs,
+        dki_csf, dki_wm, dki_gm,
         rumba_fit, rumba_params, rumba_model,
         rumba_f_csf, rumba_f_gm, rumba_f_wm,
         csd_params, get_bundle_dict])

--- a/AFQ/tasks/tractography.py
+++ b/AFQ/tasks/tractography.py
@@ -13,7 +13,7 @@ from AFQ.tasks.utils import with_name
 from AFQ.definitions.utils import Definition
 import AFQ.tractography.tractography as aft
 from AFQ.tasks.utils import get_default_args
-from AFQ.definitions.image import ScalarImage
+from AFQ.definitions.image import ScalarImage, DKI3TImage, DkiGmWmInterfaceImage
 from AFQ.tractography.utils import gen_seeds, get_percentile_threshold
 
 from trx.trx_file_memmap import TrxFile
@@ -129,12 +129,16 @@ def export_stop_mask_thresholded(data_imap, stop, tracking_params):
     full path to a nifti file containing the
     tractography stop mask thresholded
     """
-    thresh = tracking_params['stop_threshold']
-    threshed_data = nib.load(stop).get_fdata() > thresh
-    stop_mask_desc = dict(source=stop, thresh=thresh)
-    return nib.Nifti1Image(
-        threshed_data.astype(np.float32),
-        data_imap["dwi_affine"]), stop_mask_desc
+    if isinstance(tracking_params['stop_threshold'], str):
+        raise ValueError("Cannot generate thresholded "
+                         "stop mask for CMC or ACT")
+    else:
+        thresh = tracking_params['stop_threshold']
+        threshed_data = nib.load(stop).get_fdata() > thresh
+        stop_mask_desc = dict(source=stop, thresh=thresh)
+        return nib.Nifti1Image(
+            threshed_data.astype(np.float32),
+            data_imap["dwi_affine"]), stop_mask_desc
 
 
 @pimms.calc("stop")
@@ -442,25 +446,41 @@ def get_tractography_plan(kwargs):
         kwargs["tracking_params"]["odf_model"] =\
             kwargs["tracking_params"]["odf_model"].upper()
     if kwargs["tracking_params"]["seed_mask"] is None:
-        kwargs["tracking_params"]["seed_mask"] = ScalarImage(
-            kwargs["best_scalar"])
-        kwargs["tracking_params"]["seed_threshold"] = 0.2
-        logger.info((
-            "No seed mask given, using FA (or first scalar if none are FA)"
-            "thresholded to 0.2"))
+        if kwargs["tracking_params"]["tracker"] == "pft":
+            kwargs["tracking_params"]["seed_mask"] = DkiGmWmInterfaceImage()
+            kwargs["tracking_params"]["seed_threshold"] = 0.5
+            logger.info((
+                "No seed mask given, using GM-WM interface "
+                "from 3T prob maps esimated from DKI"))
+        else:
+            kwargs["tracking_params"]["seed_mask"] = ScalarImage(
+                kwargs["best_scalar"])
+            kwargs["tracking_params"]["seed_threshold"] = 0.2
+            logger.info((
+                "No seed mask given, using FA "
+                "(or first scalar if none are FA) "
+                "thresholded to 0.2"))
     if kwargs["tracking_params"]["stop_mask"] is None:
-        kwargs["tracking_params"]["stop_mask"] = ScalarImage(
-            kwargs["best_scalar"])
-        kwargs["tracking_params"]["stop_threshold"] = 0.2
-        logger.info((
-            "No stop mask given, using FA (or first scalar if none are FA)"
-            "thresholded to 0.2"))
+        if kwargs["tracking_params"]["tracker"] == "pft":
+            kwargs["tracking_params"]["stop_threshold"] = "CMC"
+            kwargs["tracking_params"]["stop_mask"] = DKI3TImage()
+            logger.info((
+                "No stop mask given, using CMC "
+                "and 3T prob maps esimated from DKI"))
+        else:
+            kwargs["tracking_params"]["stop_mask"] = ScalarImage(
+                kwargs["best_scalar"])
+            kwargs["tracking_params"]["stop_threshold"] = 0.2
+            logger.info((
+                "No stop mask given, using FA "
+                "(or first scalar if none are FA) "
+                "thresholded to 0.2"))
 
     stop_mask = kwargs["tracking_params"]['stop_mask']
     seed_mask = kwargs["tracking_params"]['seed_mask']
     odf_model = kwargs["tracking_params"]['odf_model']
 
-    if kwargs["tracking_params"]["tracker"] == "pft":
+    if isinstance(kwargs["tracking_params"]["stop_threshold"], str):
         probseg_funcs = stop_mask.get_image_getter("tractography")
         tractography_tasks["wm_res"] = pimms.calc("pve_wm")(probseg_funcs[0])
         tractography_tasks["gm_res"] = pimms.calc("pve_gm")(probseg_funcs[1])

--- a/AFQ/tractography/tractography.py
+++ b/AFQ/tractography/tractography.py
@@ -172,38 +172,18 @@ def track(params_file, directions="prob", max_angle=30., sphere=None,
         dg = dg.from_shcoeff(model_params, max_angle=max_angle, sphere=sphere,
                              basis_type=basis_type, legacy=legacy)
 
-    if tracker == "local":
-        if stop_mask is None:
-            stop_mask = np.ones(params_img.shape[:3])
+    if stop_mask is None:
+        stop_mask = np.ones(params_img.shape[:3])
 
-        if len(np.unique(stop_mask)) <= 2:
-            stopping_criterion = ThresholdStoppingCriterion(stop_mask,
-                                                            0.5)
-        else:
-            if thresholds_as_percentages:
-                stop_threshold = get_percentile_threshold(
-                    stop_mask, stop_threshold)
-            stop_mask_copy = np.copy(stop_mask)
-            stop_thresh_copy = np.copy(stop_threshold)
-            stopping_criterion = ThresholdStoppingCriterion(stop_mask_copy,
-                                                            stop_thresh_copy)
-
-        my_tracker = LocalTracking
-
-    elif tracker == "pft":
-        if not isinstance(stop_threshold, str):
-            raise RuntimeError(
-                "You are using PFT tracking, but did not provide a string ",
-                "'stop_threshold' input. ",
-                "Possible inputs are: 'CMC' or 'ACT'")
+    if isinstance(stop_threshold, str):
         if not (isinstance(stop_mask, Iterable) and len(stop_mask) == 3):
             raise RuntimeError(
-                "You are using PFT tracking, but did not provide a length "
+                "You are using CMC/ACT stropping, but did not provide a length "
                 "3 iterable for `stop_mask`. "
                 "Expected a (pve_wm, pve_gm, pve_csf) tuple.")
         pves = []
         pve_imgs = []
-        for ii, pve in enumerate(stop_mask):
+        for pve in stop_mask:
             if isinstance(pve, str):
                 img = nib.load(pve)
             else:
@@ -226,7 +206,6 @@ def track(params_file, directions="prob", max_angle=30., sphere=None,
             moving_affine=pve_csf_img.affine,
             static_affine=params_img.affine).get_fdata()
 
-        my_tracker = ParticleFilteringTracking
         if stop_threshold == "CMC":
             stopping_criterion = CmcStoppingCriterion.from_pve(
                 pve_wm_data,
@@ -240,6 +219,26 @@ def track(params_file, directions="prob", max_angle=30., sphere=None,
                 pve_wm_data,
                 pve_gm_data,
                 pve_csf_data)
+    else:
+        if len(np.unique(stop_mask)) <= 2:
+            stopping_criterion = ThresholdStoppingCriterion(stop_mask,
+                                                            0.5)
+        else:
+            if thresholds_as_percentages:
+                stop_threshold = get_percentile_threshold(
+                    stop_mask, stop_threshold)
+            stop_mask_copy = np.copy(stop_mask)
+            stop_thresh_copy = np.copy(stop_threshold)
+            stopping_criterion = ThresholdStoppingCriterion(stop_mask_copy,
+                                                            stop_thresh_copy)
+
+    if tracker == "local":
+        my_tracker = LocalTracking
+    elif tracker == "pft":
+        my_tracker = ParticleFilteringTracking
+    else:
+        raise ValueError(f"Unrecognized tracker '{tracker}'. Must be one of "
+                         "{'local', 'pft'}.")
 
     logger.info(
         f"Tracking with {len(seeds)} seeds, 2 directions per seed...")

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,6 +33,7 @@ install_requires =
     pybids>=0.16.2
     templateflow>=0.8
     pimms
+    numba
     pydra
     trx-python
     ray


### PR DESCRIPTION
This is a few things I have been trying out to modernize pyAFQ on multi-shell images, as well as some random things.
They are:
 1. Add a pseudo-t1 generated according to: . This is currently unused, but is kind of neat.
 2. Add WM, GM, CSF probability maps based on DKI and inspired by the pipeline above. They seem to work pretty well. Basically, DKI MD is used to delineate CSF, then DKI FA is used to separate WM/GM. This could be replaced by adding a T1 instead, if we want to make pyAFQ require T1s. Then, the tradeoff would be the higher resolution of the T1 against any cost from coregistration. 
 3. Add compatibility for WM/GM interface seeding based on the above WM/GM/CSF segmentations from DKI. 
 4. Add an in-house MSMT solver based on the one I wrote for the GPU a few months back. I have tested this on only two subjects but it works perfectly on both. I would like more testing before I move this to DIPY. it only requires numba, and took ~16 minutes to run on an example HBN subject on my mac laptop. It uses the primal-dual interior points method with conjugate gradients for solving and the Mehrotra predictor–corrector method for determining step size. It takes advantage of warm starting and precomputed inputs as much as possible.
 5. I am vendorizing here some code from scilpy for doing unified filtering to get asymmetric ODFs. However, this code takes a long time to run. So I may end up using a different method to get aODFs.
 
 Overall, the direction here is clear. for multi shell data, some sort of 3T segmentation and ACT tracking should be default in pyAFQ, as well as MSMT and hopefully aODFs.