### PR TITLE
BF: Remove all traces of Forceps bundles.

### DIFF
--- a/AFQ/api/bundle_dict.py
+++ b/AFQ/api/bundle_dict.py
@@ -806,7 +806,7 @@ class BundleDict(MutableMapping):
                 " are co-located, and AFQ"
                 " assigns each streamline to only one bundle."
                 " Only Callosum Occipital will be used."))
-            self.bundle_names.remove("Forceps Major")
+            del self["Forceps Major"]
         if "Forceps Minor" in self.bundle_names\
                 and "Callosum Orbital" in self.bundle_names:
             self.logger.info((
@@ -814,7 +814,7 @@ class BundleDict(MutableMapping):
                 " are co-located, and AFQ"
                 " assigns each streamline to only one bundle."
                 " Only Callosum Orbital will be used."))
-            self.bundle_names.remove("Forceps Minor")
+            del self["Forceps Minor"]
         if "Forceps Minor" in self.bundle_names\
                 and "Callosum Anterior Frontal" in self.bundle_names:
             self.logger.info((
@@ -822,7 +822,7 @@ class BundleDict(MutableMapping):
                 " are co-located, and AFQ"
                 " assigns each streamline to only one bundle."
                 " Only Callosum Anterior Frontal will be used."))
-            self.bundle_names.remove("Forceps Minor")
+            del self["Forceps Minor"]
 
     def __print__(self):
         print(self._dict)

--- a/AFQ/api/group.py
+++ b/AFQ/api/group.py
@@ -445,7 +445,7 @@ class GroupAFQ(object):
 
             sls_dict = {}
             load_next_subject()  # load first subject
-            for b in bundle_dict.keys():
+            for b in bundle_dict.bundle_names:
                 for i in range(len(self.valid_sub_list)):
                     seg_sft, mapping = subses_info[i]
                     idx = seg_sft.bundle_idxs[b]
@@ -683,7 +683,7 @@ class GroupAFQ(object):
         view : str
             Which view to display. Can be one of sagittal, coronal, or axial.
         direc : str
-            Which direction to views. Can be one of left, right, top, bottom, 
+            Which direction to views. Can be one of left, right, top, bottom,
             front, back
         slice_pos : float, or None
             If float, indicates the fractional position along the

--- a/AFQ/tests/test_bundle_dict.py
+++ b/AFQ/tests/test_bundle_dict.py
@@ -29,6 +29,9 @@ def test_BundleDict():
 
     assert len(afq_bundles) == 2
 
+    del afq_bundles["Left Arcuate"]
+    assert len(afq_bundles) == 1
+
     # Forceps Minor and Major
     afq_bundles = abd.default18_bd()["Forceps Major", "Forceps Minor"]
 


### PR DESCRIPTION
Calling to the `__del_item__` method instead of removing these just from the list of `bundle_names` should remove the key as well as the name.

This partially address #115, I believe.