### PR TITLE
Fixes after merge of #155.

### DIFF
--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -39,8 +39,8 @@ jobs:
           python-version: "3.11"
       - name: Display Python version
         run: python -c "import sys; print(sys.version)"
-      - name: Install sdist with optional dependencies
-        run: pip install "dist/*.tar.gz[all]"
+      - name: Install sdist without optional dependencies
+        run: pip install dist/*.tar.gz
       - run: python -c 'import AFQ; print(AFQ.__version__)'
       - name: Install pytest
         run: pip install pytest


### PR DESCRIPTION
- Back off installation of sdist with all dependencies.
- Tests should still be fine because onnxruntime now optional.