### PR TITLE
MAINT: Move setuptools_scm config to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,3 +39,4 @@ markers = [
 
 [tool.setuptools_scm]
 write_to = "AFQ/version.py"
+local_scheme = "no-local-version"

--- a/setup.py
+++ b/setup.py
@@ -1,26 +1,8 @@
 from setuptools import setup
-import string
 import os.path as op
 import glob
-from setuptools_scm import get_version
 from setuptools.command.build_py import build_py
 
-
-def local_version(version):
-    """
-    Patch in a version that can be uploaded to test PyPI
-    """
-    scm_version = get_version()
-    if "dev" in scm_version:
-        gh_in_int = []
-        for char in version.node:
-            if char.isdigit():
-                gh_in_int.append(str(char))
-            else:
-                gh_in_int.append(str(string.ascii_letters.find(char)))
-        return "".join(gh_in_int)
-    else:
-        return ""
 
 class build_py_with_references(build_py):
     def run(self):
@@ -43,9 +25,6 @@ class build_py_with_references(build_py):
         super().run()
 
 opts = dict(
-    use_scm_version={"root": ".", "relative_to": __file__,
-                     "write_to": op.join("AFQ", "version.py"),
-                     "local_scheme": local_version},
     scripts=[op.join('bin', op.split(f)[-1]) for f in glob.glob('bin/*')],
     cmdclass={"build_py": build_py_with_references},
     package_data={


### PR DESCRIPTION
Also gets rid of horrid hack to avoid local versions, which cannot be uploaded to testpypi for purpose of testing uploads on merges.