### PR TITLE
[FIX] SLF and callosal defaults

### DIFF
--- a/AFQ/api/bundle_dict.py
+++ b/AFQ/api/bundle_dict.py
@@ -555,6 +555,14 @@ def slf_bd():
             },
         },
         citations={"Sagi2024"},
+        criteria_for_all={
+            "mahal": {
+                "distance_threshold": 3,
+                "length_threshold": 3,
+                "clean_rounds": 5,
+                "remove_lengths": "both",
+            },
+        },
     )
 
 
@@ -976,7 +984,6 @@ def callosal_bd():
         },
         citations={"Dougherty2007"},
         criteria_for_all={
-            "isolation_forest": {},
             "exclude": [templates["CST_roi1_L"], templates["CST_roi1_R"]],
             "space": "template",
         },


### PR DESCRIPTION
Callosal Bundles returned to Mahalanobis cleaning, for now.

Stronger cleaning on SLF subbundles.

Both of these may need refinement before 3.0 ; Motor and Temporal bundles may need to be removed. They often are more incorrect compared to our other default bundles. 