### PR TITLE
[FIX] More reliable brain masking/FA

### DIFF
--- a/AFQ/models/dki.py
+++ b/AFQ/models/dki.py
@@ -11,14 +11,6 @@ import AFQ.utils.models as ut
 __all__ = ["fit_dki", "predict"]
 
 
-def _fit(gtab, data, mask=None, return_S0_hat=False):
-    dkimodel = dki.DiffusionKurtosisModel(gtab, return_S0_hat=return_S0_hat)
-    return dkimodel.fit(
-        data,
-        mask=mask,
-    )
-
-
 def fit_dki(
     data_files,
     bval_files,

--- a/AFQ/models/msmt.py
+++ b/AFQ/models/msmt.py
@@ -28,12 +28,6 @@ def _fit(self, data, mask=None):
     for i in range(A.shape[0]):
         A[i] /= np.linalg.norm(A[i])
 
-    A_outer = np.empty((n, n, m), dtype=np.float64)
-    for k in range(m):
-        for i in range(n):
-            for j in range(n):
-                A_outer[i, j, k] = A[k, i] * A[k, j]
-
     Q = R.T @ R
 
     A = csr_matrix(A)

--- a/AFQ/tasks/data.py
+++ b/AFQ/tasks/data.py
@@ -1,6 +1,7 @@
 import logging
 
 import dipy.core.gradients as dpg
+import dipy.reconst.dki as dipy_dki
 import dipy.reconst.dki as dpy_dki
 import dipy.reconst.dti as dpy_dti
 import dipy.reconst.fwdti as dpy_fwdti
@@ -27,7 +28,6 @@ from AFQ.models.asym_filtering import (
 )
 from AFQ.models.csd import CsdNanResponseError
 from AFQ.models.csd import _fit as csd_fit_model
-from AFQ.models.dki import _fit as dki_fit_model
 from AFQ.models.dti import _fit as dti_fit_model
 from AFQ.models.dti import noise_from_b0
 from AFQ.models.fwdti import _fit as fwdti_fit_model
@@ -315,7 +315,11 @@ def dki_params(brain_mask, gtab, data, citations):
             )
         )
     mask = nib.load(brain_mask).get_fdata()
-    dkf = dki_fit_model(gtab, data, mask=mask, return_S0_hat=True)
+    dkimodel = dipy_dki.DiffusionKurtosisModel(gtab, return_S0_hat=True)
+    dkf = dkimodel.fit(
+        data,
+        mask=mask,
+    )
     meta = dict(
         Description=(
             "Diffusion Coefficient, encoded as a kurtosis tensor representation"
@@ -408,7 +412,9 @@ def msdki_msd(msdki_tf):
     full path to a nifti file containing
     the MSDKI mean signal diffusivity
     """
-    return msdki_tf.msd, {"Description": "Mean Signal Diffusivity"}
+    msd = msdki_tf.msd
+    msd[msd < 0] = 0
+    return msd, {"Description": "Mean Signal Diffusivity"}
 
 
 @immlib.calc("msdki_msk")
@@ -419,7 +425,10 @@ def msdki_msk(msdki_tf):
     full path to a nifti file containing
     the MSDKI mean signal kurtosis
     """
-    return msdki_tf.msk, {"Description": "Mean Signal Kurtosis"}
+    msk = msdki_tf.msk
+    msk[msk < 0] = 0
+    msk[msk > 10] = 0
+    return msk, {"Description": "Mean Signal Kurtosis"}
 
 
 @immlib.calc("csd_params")
@@ -1480,7 +1489,13 @@ def get_data_plan(kwargs):
     if "scalars" not in kwargs:
         bvals, _ = read_bvals_bvecs(kwargs["bval_file"], kwargs["bvec_file"])
         if len(dpg.unique_bvals_magnitude(bvals)) > 2:
-            kwargs["scalars"] = ["dki_fa", "dki_md", "dki_kfa", "dki_mk", "t1w_over_b0"]
+            kwargs["scalars"] = [
+                "dti_fa",
+                "dti_md",
+                "t1w_over_b0",
+                "msdki_msd",
+                "msdki_msk",
+            ]
         else:
             kwargs["scalars"] = ["dti_fa", "dti_md", "t1w_over_b0"]
     else:

--- a/AFQ/tasks/data.py
+++ b/AFQ/tasks/data.py
@@ -1,7 +1,6 @@
 import logging
 
 import dipy.core.gradients as dpg
-import dipy.reconst.dki as dipy_dki
 import dipy.reconst.dki as dpy_dki
 import dipy.reconst.dti as dpy_dti
 import dipy.reconst.fwdti as dpy_fwdti
@@ -315,7 +314,7 @@ def dki_params(brain_mask, gtab, data, citations):
             )
         )
     mask = nib.load(brain_mask).get_fdata()
-    dkimodel = dipy_dki.DiffusionKurtosisModel(gtab, return_S0_hat=True)
+    dkimodel = dpy_dki.DiffusionKurtosisModel(gtab, return_S0_hat=True)
     dkf = dkimodel.fit(
         data,
         mask=mask,
@@ -412,7 +411,7 @@ def msdki_msd(msdki_tf):
     full path to a nifti file containing
     the MSDKI mean signal diffusivity
     """
-    msd = msdki_tf.msd
+    msd = msdki_tf.msd.copy()
     msd[msd < 0] = 0
     return msd, {"Description": "Mean Signal Diffusivity"}
 
@@ -425,7 +424,7 @@ def msdki_msk(msdki_tf):
     full path to a nifti file containing
     the MSDKI mean signal kurtosis
     """
-    msk = msdki_tf.msk
+    msk = msdki_tf.msk.copy()
     msk[msk < 0] = 0
     msk[msk > 10] = 0
     return msk, {"Description": "Mean Signal Kurtosis"}

--- a/AFQ/tasks/segmentation.py
+++ b/AFQ/tasks/segmentation.py
@@ -398,14 +398,14 @@ def get_scalar_dict(
         "dki_mk", or other scalars found in AFQ.tasks.data.
         Can also be a scalar from AFQ.definitions.image.
         Finally, can also be "t1w".
-        Defaults for single shell data to ["dti_fa", "dti_md", "t1w"],
-        and for multi-shell data to ["dki_fa", "dki_md", "dki_kfa",
-        "dki_mk", "t1w"].
-        Default: ['dti_fa', 'dti_md', 't1w']
+        Defaults for single shell data to ["dti_fa", "dti_md", "t1w_over_b0"],
+        and for multi-shell data to ["dti_fa", "dti_md", "t1w_over_b0",
+        "msdki_msd", "msdki_msk"].
+        Default: ['dti_fa', 'dti_md', 't1w_over_b0']
     """
-    # Note: some scalars preprocessing done in mapping plan, before this step
+    # Note: some scalars preprocessing done in data plan, before this step
     if scalars is None:
-        scalars = ["dti_fa", "dti_md", "t1w"]
+        scalars = ["dti_fa", "dti_md", "t1w_over_b0"]
     scalar_dict = {}
     for scalar in scalars:
         if isinstance(scalar, str):

--- a/AFQ/tasks/structural.py
+++ b/AFQ/tasks/structural.py
@@ -155,23 +155,26 @@ def t1w_brain_mask(synthseg_model, brain_mask_definition=None):
         the brain mask, which gets applied before registration to a
         template.
         If you want no brain mask to be applied, use FullImage.
-        If None, use Brainchop Mindgrab model.
+        If None, use Synthseg model.
         Default: None
 
     References
     ----------
-    [1] Masoud, M., Hu, F., & Plis, S. (2023). Brainchop: In-browser MRI
-        volumetric segmentation and rendering. Journal of Open Source
-        Software, 8(83), 5098.
-        https://doi.org/10.21105/joss.05098
+    [1] Billot, Benjamin, et al. "Robust machine learning segmentation
+        for large-scale analysis of heterogeneous clinical brain MRI
+        datasets." Proceedings of the National Academy of Sciences 120.9
+        (2023): e2216399120.
+    [2] Billot, Benjamin, et al. "SynthSeg: Segmentation of brain MRI scans
+        of any contrast and resolution without retraining." Medical image
+        analysis 86 (2023): 102789.
     """
     # Note that any case where brain_mask_definition is not None
-    # is handled in get_data_plan
+    # is handled in get_structural_plan
     # This is just the default
 
-    predictions = nib.load(synthseg_model).get_fdata()
-    brain_mask = (predictions > 0).astype(np.uint8)
-    brain_mask_img = nib.Nifti1Image(brain_mask, nib.load(synthseg_model).affine)
+    predictions = nib.load(synthseg_model)
+    brain_mask = (predictions.get_fdata() > 0).astype(np.uint8)
+    brain_mask_img = nib.Nifti1Image(brain_mask, predictions.affine)
     return brain_mask_img, dict(SynthsegPredictions=synthseg_model)
 
 

--- a/AFQ/tasks/structural.py
+++ b/AFQ/tasks/structural.py
@@ -2,6 +2,7 @@ import logging
 
 import immlib
 import nibabel as nib
+import numpy as np
 from numba import get_num_threads
 
 from AFQ.definitions.utils import Definition
@@ -90,7 +91,7 @@ def onnx_kwargs(
 
 @immlib.calc("synthseg_model")
 @as_file(suffix="_model-synthseg2_probseg.nii.gz", subfolder="nn")
-def synthseg_model(t1_masked, citations, onnx_kwargs):
+def synthseg_model(t1_file, citations, onnx_kwargs):
     """
     full path to the synthseg2 model segmentations
 
@@ -110,9 +111,9 @@ def synthseg_model(t1_masked, citations, onnx_kwargs):
         "SynthSeg 2.0",
         "Or, provide your own segmentations using PVEImage or PVEImages.",
     )
-    t1_img = nib.load(t1_masked)
+    t1_img = nib.load(t1_file)
     predictions = run_synthseg(ort, t1_img, "synthseg2", onnx_kwargs)
-    return predictions, dict(T1w=t1_masked)
+    return predictions, dict(T1w=t1_file)
 
 
 @immlib.calc("mx_model")
@@ -143,7 +144,7 @@ def mx_model(t1_file, t1w_brain_mask, citations, onnx_kwargs):
 
 @immlib.calc("t1w_brain_mask")
 @as_file(suffix="_desc-T1w_mask.nii.gz")
-def t1w_brain_mask(t1_file, citations, onnx_kwargs, brain_mask_definition=None):
+def t1w_brain_mask(synthseg_model, brain_mask_definition=None):
     """
     full path to a nifti file containing brain mask from T1w image
 
@@ -168,14 +169,10 @@ def t1w_brain_mask(t1_file, citations, onnx_kwargs, brain_mask_definition=None):
     # is handled in get_data_plan
     # This is just the default
 
-    citations.add("fani2025mindgrab")
-
-    ort = check_onnxruntime(
-        "Mindgrab", "Or, provide your own brain mask using brain_mask_definition."
-    )
-    return run_brainchop(ort, nib.load(t1_file), "mindgrab", onnx_kwargs), dict(
-        T1w=t1_file, model="mindgrab"
-    )
+    predictions = nib.load(synthseg_model).get_fdata()
+    brain_mask = (predictions > 0).astype(np.uint8)
+    brain_mask_img = nib.Nifti1Image(brain_mask, nib.load(synthseg_model).affine)
+    return brain_mask_img, dict(SynthsegPredictions=synthseg_model)
 
 
 @immlib.calc("t1_masked")

--- a/AFQ/tests/test_api.py
+++ b/AFQ/tests/test_api.py
@@ -340,7 +340,7 @@ def test_AFQ_init():
                     dwi_preproc_pipeline="synthetic",
                     participant_labels=participant_labels,
                 )
-                myafq.export("dwi")
+                myafq.export("b0")
 
 
 @pytest.mark.nightly_basic

--- a/AFQ/tests/test_api.py
+++ b/AFQ/tests/test_api.py
@@ -990,11 +990,19 @@ def test_AFQ_data_waypoint():
         'suffix="seg", filters={"scope": "freesurfer"},'
         "inclusive_labels=[1, 2]))"
     )
+    bm_def_as_str = (
+        "LabelledImageFile(suffix='seg', "
+        "filters={'scope': 'freesurfer'}, "
+        "exclusive_labels=[0])"
+    )
     config = dict(
         BIDS_PARAMS=dict(
             bids_path=bids_path,
             dwi_preproc_pipeline="vistasoft",
             t1_preproc_pipeline="freesurfer",
+        ),
+        STRUCTURAL=dict(
+            brain_mask_definition=bm_def_as_str,
         ),
         DATA=dict(bundle_info=bundle_dict_as_str),
         TISSUE=dict(pve=pve_as_str),

--- a/AFQ/viz/altair.py
+++ b/AFQ/viz/altair.py
@@ -139,7 +139,7 @@ def altair_df_to_chart(
         "DTI FA": "",
         "DTI MD": " (µm²/ms)",
         "MSDKI MSD": " (µm²/ms)",
-        "MSDKI MSk": "",
+        "MSDKI MSK": "",
         "T1W OVER B0": "",
     }
 

--- a/AFQ/viz/altair.py
+++ b/AFQ/viz/altair.py
@@ -138,6 +138,9 @@ def altair_df_to_chart(
         "DKI MK": "",
         "DTI FA": "",
         "DTI MD": " (µm²/ms)",
+        "MSDKI MSD": " (µm²/ms)",
+        "MSDKI MSk": "",
+        "T1W OVER B0": "",
     }
 
     if bundle_list is None:

--- a/docs/source/reference/kwargs.rst
+++ b/docs/source/reference/kwargs.rst
@@ -30,7 +30,7 @@ onnx_inter_threads: int
 	The number of inter threads to use for onnx models. Increasing will increase memory usage significantly. Default: 1
 
 brain_mask_definition: instance from `AFQ.definitions.image`
-	This will be used to create the brain mask, which gets applied before registration to a template. If you want no brain mask to be applied, use FullImage. If None, use Brainchop Mindgrab model. Default: None
+	This will be used to create the brain mask, which gets applied before registration to a template. If you want no brain mask to be applied, use FullImage. If None, use Synthseg model. Default: None
 
 
 ==========================================================
@@ -136,7 +136,7 @@ n_points_profile: int
 	Number of points to resample each streamline to before calculating the tract-profiles. Default: 100
 
 scalars: list of strings and/or scalar definitions
-	List of scalars to use. Can be any of: "dti_fa", "dti_md", "dki_fa", "dki_md", "dki_awf", "dki_mk", or other scalars found in AFQ.tasks.data. Can also be a scalar from AFQ.definitions.image. Finally, can also be "t1w". Defaults for single shell data to ["dti_fa", "dti_md", "t1w"], and for multi-shell data to ["dki_fa", "dki_md", "dki_kfa", "dki_mk", "t1w"]. Default: ['dti_fa', 'dti_md', 't1w']
+	List of scalars to use. Can be any of: "dti_fa", "dti_md", "dki_fa", "dki_md", "dki_awf", "dki_mk", or other scalars found in AFQ.tasks.data. Can also be a scalar from AFQ.definitions.image. Finally, can also be "t1w". Defaults for single shell data to ["dti_fa", "dti_md", "t1w_over_b0"], and for multi-shell data to ["dti_fa", "dti_md", "t1w_over_b0", "msdki_msd", "msdki_msk"]. Default: ['dti_fa', 'dti_md', 't1w_over_b0']
 
 
 ==========================================================

--- a/examples/howto_examples/cloudknot_example.py
+++ b/examples/howto_examples/cloudknot_example.py
@@ -66,8 +66,7 @@ def afq_process_subject(subject):
     myafq = GroupAFQ(
         "local_bids_dir",
         dwi_preproc_pipeline="pipeline_name",
-        viz_backend_spec='plotly',  # this will generate both interactive html and GIFs # noqa
-        scalars=["dki_fa", "dki_md"])
+        viz_backend_spec='plotly')  # this will generate both interactive html and GIFs # noqa
 
     # export_all runs the entire pipeline and creates many useful derivates
     myafq.export_all()

--- a/examples/tutorial_examples/plot_001_group_afq_api.py
+++ b/examples/tutorial_examples/plot_001_group_afq_api.py
@@ -128,13 +128,13 @@ myafq = GroupAFQ(
     tracking_params=tracking_params)
 
 ##########################################################################
-# Calculating DKI FA (Diffusion Kurtosis Imaging Fractional Anisotropy)
+# Calculating DTI FA (Diffusion Tensor Imaging Fractional Anisotropy)
 # ------------------------------------------------------------------
 # The GroupAFQ object has a method called `export`, which allows the user
 # to calculate various derived quantities from the data.
 #
-# For example, FA can be computed using the DKI model, by explicitly
-# calling `myafq.export("dki_fa")`. This triggers the computation of DKI
+# For example, FA can be computed using the DTI model, by explicitly
+# calling `myafq.export("dti_fa")`. This triggers the computation of DTI
 # parameters for all subjects in the dataset, and stores the results in
 # the AFQ derivatives directory. In addition, it calculates the FA
 # from these parameters and stores it in a different file in the same
@@ -142,7 +142,7 @@ myafq = GroupAFQ(
 #
 # .. note::
 #
-#    The AFQ API computes quantities lazily. This means that DKI parameters
+#    The AFQ API computes quantities lazily. This means that DTI parameters
 #    are not computed until they are required. This means that the first
 #    line below is the one that requires time.
 #
@@ -151,7 +151,7 @@ myafq = GroupAFQ(
 # This means that to extract the filename corresponding to the FA of the first
 # subject, we can do:
 
-FA_fname = myafq.export("dki_fa", collapse=False)["NDARAA948VFH"]["HBNsiteRU"]
+FA_fname = myafq.export("dti_fa", collapse=False)["NDARAA948VFH"]["HBNsiteRU"]
 
 # We will then use `nibabel` to load the deriviative file and retrieve the
 # data array.
@@ -240,7 +240,12 @@ fig_files = myafq.export("tract_profile_plots", collapse=False)[
 profiles_df = myafq.combine_profiles()
 altair_df = ava.combined_profiles_df_to_altair_df(
     profiles_df,
-    tissue_properties=['dki_fa', 'dki_md'])
+    tissue_properties=[
+        "dti_fa",
+        "dti_md",
+        "t1w_over_b0",
+        "msdki_msd",
+        "msdki_msk"])
 altair_chart = ava.altair_df_to_chart(altair_df)
 altair_chart.display()
 

--- a/examples/tutorial_examples/plot_002_participant_afq_api.py
+++ b/examples/tutorial_examples/plot_002_participant_afq_api.py
@@ -145,27 +145,27 @@ myafq = ParticipantAFQ(
 )
 
 ##########################################################################
-# Calculating DKI FA (Diffusion Tensor Imaging Fractional Anisotropy)
+# Calculating DTI FA (Diffusion Tensor Imaging Fractional Anisotropy)
 # ------------------------------------------------------------------
 # The ParticipantAFQ object has a method called ``export``, which allows the user
 # to calculate various derived quantities from the data.
 #
-# For example, FA can be computed using the DKI model, by explicitly
-# calling ``myafq.export("dki_fa")``. This triggers the computation of DKI
+# For example, FA can be computed using the DTI model, by explicitly
+# calling ``myafq.export("dti_fa")``. This triggers the computation of DTI
 # parameters, and stores the results in the AFQ derivatives directory.
 # In addition, it calculates the FA from these parameters and stores it in a
 # different file in the same directory.
 #
 # .. note::
 #
-#    The AFQ API computes quantities lazily. This means that DKI parameters
+#    The AFQ API computes quantities lazily. This means that DTI parameters
 #    are not computed until they are required. This means that the first
 #    line below is the one that requires time.
 #
 # The result of the call to ``export`` is the filename of the corresponding FA
 # files.
 
-FA_fname = myafq.export("dki_fa")
+FA_fname = myafq.export("dti_fa")
 
 ##########################################################################
 # We will then use ``nibabel`` to load the deriviative file and retrieve the

--- a/examples/tutorial_examples/plot_004_export.py
+++ b/examples/tutorial_examples/plot_004_export.py
@@ -100,24 +100,24 @@ myafq.export("help")
 
 
 ##########################################################################
-# Calculating DKI FA (Diffusion Tensor Imaging Fractional Anisotropy)
+# Calculating DTI FA (Diffusion Tensor Imaging Fractional Anisotropy)
 # ------------------------------------------------------------------
-# FA can be computed using the DKI model, by explicitly calling
-# ``myafq.export("dki_fa")``. This triggers the computation of DKI parameters,
+# FA can be computed using the DTI model, by explicitly calling
+# ``myafq.export("dti_fa")``. This triggers the computation of DTI parameters,
 # and stores the results in the AFQ derivatives directory. In addition, it
 # calculates the FA from these parameters and stores it in a different file in
 # the same directory.
 #
 # .. note::
 #
-#    The AFQ API computes quantities lazily. This means that DKI parameters
+#    The AFQ API computes quantities lazily. This means that DTI parameters
 #    are not computed until they are required. This means that the first
 #    line below is the one that requires time.
 #
 # The result of the call to ``export`` is the filename of the corresponding FA
 # files.
 
-FA_fname = myafq.export("dki_fa")
+FA_fname = myafq.export("dti_fa")
 
 
 ##########################################################################


### PR DESCRIPTION
(1) Currently, with DIPY defaults, DKI does not fit in many voxels in HCP subjects. I am looking into fixing this, but for now, let's just use DTI FA
(2) Adds MSDKI metrics to defaults. They calculate easily and provide some complementary information.
(3) Changes default brain mask from brainchop to synthseg. I have just noticed synthseg is more reliable.