### PR TITLE
[ENH/FIX] Add flag to turn off clipping during cleaning when clip_edges is True

### DIFF
--- a/AFQ/recognition/criteria.py
+++ b/AFQ/recognition/criteria.py
@@ -663,12 +663,11 @@ def recognize_bundles(
     tol, dist_to_atlas, vox_dim = abu.tolerance_mm_to_vox(
         img, dist_to_waypoint, dist_to_atlas
     )
+
     preproc_scalars = {
         "vox_dim": vox_dim,
         "tol": tol,
         "dist_to_atlas": dist_to_atlas,
-        "clip_for_clean": not segmentation_params["clean_unclipped"]
-        and (segmentation_params["clip_edges"] or ("bundlesection" in bundle_def)),
     }
 
     bundle_defs = {}
@@ -765,6 +764,10 @@ def recognize_bundles(
             candidate_global_idx = None
             fgarray_for_candidates = None
 
+        clip_for_clean = not segmentation_params["clean_unclipped"] and (
+            segmentation_params["clip_edges"] or ("bundlesection" in bundle_def)
+        )
+
         _run_global_phase(
             bundle_def,
             bundle_name,
@@ -780,6 +783,7 @@ def recognize_bundles(
             tol,
             dist_to_atlas,
             save_intermediates=save_intermediates,
+            clip_for_clean=clip_for_clean,
             **segmentation_params,
         )
 

--- a/AFQ/recognition/criteria.py
+++ b/AFQ/recognition/criteria.py
@@ -308,16 +308,15 @@ def recobundles(
     b_sls.select(rec_labels, "Recobundles")
 
 
-def qb_thresh(b_sls, bundle_def, clip_edges, **kwargs):
+def qb_thresh(b_sls, bundle_def, clip_for_clean, **kwargs):
     b_sls.initiate_selection("qb_thresh")
-    cut = clip_edges or ("bundlesection" in bundle_def)
     qbx = QuickBundles(
         bundle_def["qb_thresh"],
         AveragePointwiseEuclideanMetric(ResampleFeature(nb_points=12)),
     )
-    clusters = qbx.cluster(b_sls.get_selected_sls(cut=cut, flip=True))
+    clusters = qbx.cluster(b_sls.get_selected_sls(cut=clip_for_clean, flip=True))
     cleaned_idx = clusters[np.argmax(clusters.clusters_sizes())].indices
-    b_sls.select(cleaned_idx, "qb_thresh", cut=cut)
+    b_sls.select(cleaned_idx, "qb_thresh", cut=clip_for_clean)
 
 
 def clean_by_other_bundle(
@@ -366,35 +365,34 @@ def clean_by_other_bundle(
     b_sls.select(cleaned_idx, other_bundle_name)
 
 
-def orient_mahal(b_sls, bundle_def, **kwargs):
+def orient_mahal(b_sls, bundle_def, clip_for_clean, **kwargs):
     b_sls.initiate_selection("orient_mahal")
     accept_idx = abc.clean_by_orientation_mahalanobis(
-        b_sls.get_selected_sls(), **bundle_def.get("orient_mahal", {})
+        b_sls.get_selected_sls(cut=clip_for_clean), **bundle_def.get("orient_mahal", {})
     )
-    b_sls.select(accept_idx, "orient_mahal")
+    b_sls.select(accept_idx, "orient_mahal", cut=clip_for_clean)
 
 
-def isolation_forest(b_sls, bundle_def, rng, **kwargs):
+def isolation_forest(b_sls, bundle_def, clip_for_clean, rng, **kwargs):
     b_sls.initiate_selection("isolation_forest")
     accept_idx = abc.clean_by_isolation_forest(
-        b_sls.get_selected_sls(),
+        b_sls.get_selected_sls(cut=clip_for_clean),
         distance_threshold=bundle_def["isolation_forest"].get("distance_threshold", 3),
         n_rounds=bundle_def["isolation_forest"].get("n_rounds", 5),
         random_state=rng,
     )
-    b_sls.select(accept_idx, "isolation_forest")
+    b_sls.select(accept_idx, "isolation_forest", cut=clip_for_clean)
 
 
-def mahalanobis(b_sls, bundle_def, clip_edges, cleaning_params, **kwargs):
+def mahalanobis(b_sls, bundle_def, clip_for_clean, cleaning_params, **kwargs):
     b_sls.initiate_selection("Mahalanobis")
     clean_params = bundle_def.get("mahal", {})
     clean_params = {**cleaning_params, **clean_params}
     clean_params["return_idx"] = True
-    cut = clip_edges or ("bundlesection" in bundle_def)
     _, cleaned_idx = abc.clean_bundle(
-        b_sls.get_selected_sls(cut=cut, flip=True), **clean_params
+        b_sls.get_selected_sls(cut=clip_for_clean, flip=True), **clean_params
     )
-    b_sls.select(cleaned_idx, "Mahalanobis", cut=cut)
+    b_sls.select(cleaned_idx, "Mahalanobis", cut=clip_for_clean)
 
 
 def _prepare_bundle_def(bundle_dict, bundle_name, mapping, img):
@@ -669,6 +667,8 @@ def recognize_bundles(
         "vox_dim": vox_dim,
         "tol": tol,
         "dist_to_atlas": dist_to_atlas,
+        "clip_for_clean": not segmentation_params["clean_unclipped"]
+        and (segmentation_params["clip_edges"] or ("bundlesection" in bundle_def)),
     }
 
     bundle_defs = {}

--- a/AFQ/recognition/recognize.py
+++ b/AFQ/recognition/recognize.py
@@ -25,6 +25,7 @@ def recognize(
     nb_points=False,
     nb_streamlines=False,
     clip_edges=False,
+    clean_unclipped=False,
     rb_recognize_params=None,
     refine_reco=False,
     prob_threshold=0,
@@ -64,6 +65,11 @@ def recognize(
         Default: False
     clip_edges : bool
         Whether to clip the streamlines to be only in between the ROIs.
+        Default: False
+    clean_unclipped : bool
+        Whether to use the unclipped streamlines when cleaning.
+        Only considered if clip_edges is True or bundlesection
+        is in the bundle_dict.
         Default: False
     rb_recognize_params : dict
         RecoBundles parameters for the recognize function.
@@ -186,6 +192,7 @@ def recognize(
         dist_to_atlas=dist_to_atlas,
         save_intermediates=save_intermediates,
         clip_edges=clip_edges,
+        clean_unclipped=clean_unclipped,
         rb_recognize_params=rb_recognize_params,
         prob_threshold=prob_threshold,
         refine_reco=refine_reco,

--- a/AFQ/recognition/tests/test_recognition.py
+++ b/AFQ/recognition/tests/test_recognition.py
@@ -158,7 +158,13 @@ def test_segment_return_idx():
 def test_segment_clip_edges_api():
     # Test with the clip_edges kwarg set to True:
     fiber_groups, _ = recognize(
-        tg, hardi_img, mapping, bundles, reg_template, clip_edges=True
+        tg,
+        hardi_img,
+        mapping,
+        bundles,
+        reg_template,
+        clip_edges=True,
+        clean_unclipped=True,
     )
     npt.assert_equal(len(fiber_groups), 2)
     npt.assert_(len(fiber_groups["Right Corticospinal"]) > 0)


### PR DESCRIPTION
This also includes a fix to make the clipping logic for all of our cleaning methods the same (standard, orientation, quickbundles, isolation forest) .