### PR TITLE
TST: Configure docbuild workflow to display full tracebacks.

### DIFF
--- a/.github/workflows/docbuild.yml
+++ b/.github/workflows/docbuild.yml
@@ -44,7 +44,7 @@ jobs:
     - name: Build docs
       run: |
         cd docs
-        make html
+        make html SPHINXOPTS="-T"
     - name: Upload docs
       uses: actions/upload-artifact@v4
       with:


### PR DESCRIPTION
Per default, sphinx does not print out the full traceback. Instead, it prints a message like
"The full traceback has been saved in XXX".

The -T flag instead allows printing the full traceback to the terminal, which would then produce this traceback in our GHA logs.

This is related to: https://github.com/tractometry/pyAFQ/actions/runs/29887179617/job/88820001344#step:6:440