### PR TITLE
BF: Call fury object with key-word.

### DIFF
--- a/AFQ/_fixes.py
+++ b/AFQ/_fixes.py
@@ -431,7 +431,7 @@ def make_mp4(show_m, out_path, n_frames=720, az_ang=-0.5, fps=30, crf=35, verbos
             show_m.screens[0].controller.rotate((radians(az_ang), 0), None)
             show_m.render()
             show_m.window.draw()
-            show_m.snapshot(frame_fname)
+            show_m.snapshot(fname=frame_fname)
             video.append(Image.open(frame_fname).convert("RGB"))
 
         all_left, all_upper = float("inf"), float("inf")

--- a/AFQ/api/group.py
+++ b/AFQ/api/group.py
@@ -917,7 +917,7 @@ class GroupAFQ(object):
                     scene=figure, window_type="offscreen", size=(600, 600)
                 )
                 scene_rotate_forward(show_m, figure)
-                show_m.snapshot(this_fname)
+                show_m.snapshot(fname=this_fname)
 
         def _save_file(curr_img, curr_file_num):
             save_path = op.abspath(

--- a/AFQ/api/participant.py
+++ b/AFQ/api/participant.py
@@ -363,7 +363,7 @@ class ParticipantAFQ(object):
                         pass
                     show_m.render()
                     show_m.window.draw()
-                    show_m.snapshot(this_fname)
+                    show_m.snapshot(fname=this_fname)
 
         def _save_file(curr_img):
             save_path = op.abspath(

--- a/docs/source/examples/tutorial_examples/plot_005_viz.md
+++ b/docs/source/examples/tutorial_examples/plot_005_viz.md
@@ -207,7 +207,7 @@ def save_png(scene, name):
     show_m.screens[0].controller.rotate((0, radians(-90)), None)
     show_m.render()
     show_m.window.draw()
-    show_m.snapshot(op.join(out_folder, name))
+    show_m.snapshot(fname=op.join(out_folder, name))
 
 save_png(scene, 'arc_cst1.png')
 ```

--- a/setup.cfg
+++ b/setup.cfg
@@ -80,7 +80,7 @@ dev =
     ipython
     jupytext
 fury =
-    fury>=2.0.0a7
+    fury>=2.0.0
 fsl =
     fslpy
 afqbrowser =


### PR DESCRIPTION
This may fix nightly failures, such as: https://github.com/tractometry/pyAFQ/actions/runs/31474498272/job/93724970368#step:7:203

BTW: Why is this function in the fixes module? Shouldn't this be in viz? 